### PR TITLE
feat: enable parallel pytest execution under xdist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,4 +22,4 @@ jobs:
         run: |
           uv run mypy
           uv run dbt deps --project-dir tests/dummy_gummy
-          uv run pytest -v
+          uv run pytest -v -n auto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`pytest-dbt-duckdb` is a pytest plugin that tests dbt models end-to-end using an in-memory DuckDB instance. The plugin is registered via the `pytest11` entry point in `pyproject.toml` (`pytest_dbt_duckdb.plugin`) — installing the package automatically activates the `duckdb_fixture` for any consumer's pytest run.
+
+## Common commands
+
+Dependency management is via `uv`. The project requires Python ≥ 3.11.
+
+```bash
+# Install (mirrors CI)
+uv sync --all-extras --dev
+
+# Required before running tests: install dbt packages for the bundled sample project
+uv run dbt deps --project-dir tests/dummy_gummy
+
+# Type-check, then run the suite (matches .github/workflows/build.yml)
+uv run mypy
+uv run pytest -v
+
+# Run a single YAML scenario by its id (id is the parametrize identifier)
+uv run pytest -v -k "Validate full project"
+
+# Lint / format
+uv run ruff check .
+uv run ruff format .
+```
+
+Pre-commit hooks (`uv-lock`, `uv-sync`, `ruff`, `ruff-format`) run on commit; `pre-commit install` once after cloning.
+
+## Architecture
+
+The plugin orchestrates a three-stage flow inside `DbtValidator.validate` (`pytest_dbt_duckdb/dbt_validator.py`):
+
+1. **Load `given`** — for each input node, read the dbt model's declared columns from `parse`, `CREATE OR REPLACE TABLE` in DuckDB, then `INSERT` from the CSV/JSON fixture.
+2. **Execute dbt** — invoke `dbt seed` and/or `dbt build --select <selector>` against the temporary DuckDB database via `dbtRunner` (`pytest_dbt_duckdb/dbt_executor.py`). `--vars '{"elementary_enabled": false}'` is always injected; user-supplied `extra_vars` are appended as additional `--vars` flags.
+3. **Validate `then`** — fetch each output table and compare with `pandas.testing.assert_frame_equal` against an expected fixture loaded into a `<table>_test` companion table. DataFrames are sorted column-wise and row-wise (`DuckConnector.sort_df`) before comparison so row order is irrelevant.
+
+**Per-test isolation**: `duckdb_fixture` (`plugin.py`) creates a fresh `tempfile.TemporaryDirectory` and DuckDB file per test function. The fixture writes `DBT_DUCKDB_PATH` / `DBT_DUCKDB_DATABASE` into the env so the consumer's `profiles.yml` (which must reference these via `env_var(...)`) routes dbt to the temp database.
+
+**Snowflake compatibility layer**: `DuckConnector.register_snowflake_functions` is called on every connection setup and registers DuckDB macros / UDFs for `iff`, `bitand`, `array_size`, `array_union_agg`, `div0`, `to_decimal`, `current_timestamp`, `to_char`, `dateadd` (`pytest_dbt_duckdb/snowflake_functions.py`). This lets Snowflake-targeted dbt SQL run on DuckDB unchanged. Add new compat shims here when models reference unsupported Snowflake builtins.
+
+**Extending DuckDB**: consumers pass `ExtraFunctions(macros=[...], functions=[DuckFunction(...)])` to `execute_dbt` to register extra SQL macros and Python UDFs alongside the Snowflake shims.
+
+## Hard requirement: dbt column `data_type`
+
+Every column referenced in a `given` or `then` node **must** have an explicit `data_type` in the dbt project's `schema.yml`. The validator reads `node.columns[*].data_type` from the dbt manifest to issue `CREATE TABLE` DDL; missing types cause schema mismatches that surface as opaque test failures rather than clear errors. `MAP<...>` types are auto-rewritten to `JSON` (see `dbt_validator.dbt_insert_model` and `sql_methods.create_table`).
+
+## YAML test scenarios
+
+Scenarios live in `*.yml` / `*.yaml` files starting with `test` and are loaded via `load_yaml_tests(directory)`. Schema:
+
+```yaml
+tests:
+  - id: <unique id used as pytest parametrize id>
+    given:                           # list[DbtTestNode] — inputs to seed
+      - schema: <source schema>
+        table:  <source table>
+        path:   <CSV/JSON path relative to resources_folder>
+    seed:  <dbt seed selector>       # optional
+    build: <dbt build selector>      # optional, str or list[str]
+    then:                            # list[DbtTestNode] — expected outputs
+      - schema: <output schema>
+        table:  <output table>
+        path:   <expected CSV/JSON path>
+```
+
+The bundled example lives in `tests/resources/tests_e2e.yml` and runs against the sample dbt project at `tests/dummy_gummy/`.
+
+## Repo layout notes
+
+- `pytest_dbt_duckdb/` — the plugin (small, ~6 modules); `plugin.py` is the public surface, the rest is internal.
+- `tests/dummy_gummy/` — a self-contained dbt project used as the suite's fixture target. Treat its `dbt_project.yml`, `models/`, and `seeds/` as test data — changes here will alter test expectations.
+- `tests/resources/` — `profiles.yml` and YAML test scenarios consumed by `tests/test_dummy.py`.
+- `tests/__init__.py` — exports `dbt_project_dir` and `resources_folder` as absolute paths; reuse these rather than recomputing.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -193,6 +193,23 @@ Use them as a starting point for writing your own end-to-end dbt model tests!
 
 ---
 
+## :material-speedometer: Running tests in parallel
+
+!!! tip "Use pytest-xdist for fan-out"
+    The plugin isolates dbt artifacts per test by routing `--target-path` and `--log-path`
+    into the temporary directory owned by `duckdb_fixture`. As a result, you can safely
+    parallelise the suite with [`pytest-xdist`](https://pytest-xdist.readthedocs.io/).
+
+```shell
+pip install pytest-xdist
+pytest -n auto
+```
+
+Each xdist worker is a separate process, so the in-memory manifest cache and the
+per-test DuckDB file are naturally isolated. No additional configuration is required.
+
+---
+
 ## :octicons-light-bulb-24: Summary
 - Define input data (given), models to build (build), and expected outputs (then).
 - Configure dbt using profiles.yml and environment variables.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -201,7 +201,7 @@ Use them as a starting point for writing your own end-to-end dbt model tests!
     parallelise the suite with [`pytest-xdist`](https://pytest-xdist.readthedocs.io/).
 
 ```shell
-pip install pytest-xdist
+pip install "pytest-dbt-duckdb[parallel]"   # pulls in pytest-xdist
 pytest -n auto
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-dbt-duckdb"
-version = "0.1.16"
+version = "0.1.17"
 description = "Fearless testing for dbt models, powered by DuckDB."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -29,11 +29,15 @@ dependencies = [
     "ruamel-yaml>=0.18.10",
 ]
 
+[project.optional-dependencies]
+parallel = [
+    "pytest-xdist>=3.6.0",
+]
+
 [dependency-groups]
 dev = [
     "mypy>=1.14.1",
     "pre-commit>=4.1.0",
-    "pytest-xdist>=3.6.0",
     "ruff>=0.9.3",
     "tox>=4.24.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 dev = [
     "mypy>=1.14.1",
     "pre-commit>=4.1.0",
+    "pytest-xdist>=3.6.0",
     "ruff>=0.9.3",
     "tox>=4.24.1",
 ]

--- a/pytest_dbt_duckdb/dbt_executor.py
+++ b/pytest_dbt_duckdb/dbt_executor.py
@@ -10,11 +10,23 @@ class DbtExecException(Exception):
     pass
 
 
+_PARSE_CACHE: dict[tuple, dict] = {}
+
+
 class DbtExecutor:
-    def __init__(self, dbt_project_dir: str, profiles_dir: str, extra_vars: dict | None = None) -> None:
+    def __init__(
+        self,
+        dbt_project_dir: str,
+        profiles_dir: str,
+        extra_vars: dict | None = None,
+        target_path: str | None = None,
+        log_path: str | None = None,
+    ) -> None:
         self.dbt_project_dir = dbt_project_dir
         self.profiles_dir = profiles_dir
         self.extra_vars = extra_vars or {}
+        self.target_path = target_path
+        self.log_path = log_path
 
     def execute(self, command: str, params: list | None = None) -> dbtRunnerResult:
         dbt = dbtRunner()
@@ -22,7 +34,11 @@ class DbtExecutor:
         extra_vars = [json.dumps({key: value}) for key, value in self.extra_vars.items()]
         extra_vars = [x for val in extra_vars for x in ("--vars", val)]
 
-        invoke_command = [
+        invoke_command: list[str] = []
+        if self.log_path:
+            invoke_command += ["--log-path", self.log_path]
+
+        invoke_command += [
             command,
             "--project-dir",
             self.dbt_project_dir,
@@ -31,11 +47,24 @@ class DbtExecutor:
             "--vars",
             json.dumps({"elementary_enabled": False}),
         ] + extra_vars
+
+        if self.target_path:
+            invoke_command += ["--target-path", self.target_path]
+
         dbt_command = list(filter(lambda x: x, invoke_command + params))
         logging.info(f"DBT execute {dbt_command}")
         return dbt.invoke(dbt_command)
 
     def parse_project(self) -> dict[str, SourceDefinition | ModelNode]:
+        cache_key = (
+            self.dbt_project_dir,
+            self.profiles_dir,
+            json.dumps(self.extra_vars, sort_keys=True, default=str),
+        )
+        cached = _PARSE_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+
         res: dbtRunnerResult = self.execute(command="parse")
 
         result_sources: list[SourceDefinition] = res.result.sources.values()  # type: ignore
@@ -45,7 +74,9 @@ class DbtExecutor:
         models = [model for model in result_models if model.columns]
 
         nodes = sources + models
-        return {f"{node.schema}.{node.identifier}": node for node in nodes}
+        parsed = {f"{node.schema}.{node.identifier}": node for node in nodes}
+        _PARSE_CACHE[cache_key] = parsed
+        return parsed
 
     @staticmethod
     def validate_execution(res: dbtRunnerResult) -> None:

--- a/pytest_dbt_duckdb/plugin.py
+++ b/pytest_dbt_duckdb/plugin.py
@@ -36,6 +36,14 @@ class PyDuckSettings(BaseSettings):
     def database_file(self) -> str:
         return f"{self.database_name}.duckdb"
 
+    @property
+    def target_path(self) -> str:
+        return os.path.join(self.temp_dir, "dbt_target")
+
+    @property
+    def log_path(self) -> str:
+        return os.path.join(self.temp_dir, "dbt_logs")
+
 
 class DuckFixture(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -58,7 +66,13 @@ class DuckFixture(BaseModel):
         os.environ["DBT_DUCKDB_PATH"] = self.settings.db_file_path
         os.environ["DBT_DUCKDB_DATABASE"] = self.settings.database_name
 
-        executor = DbtExecutor(dbt_project_dir=dbt_project_dir, profiles_dir=resources_folder, extra_vars=extra_vars)
+        executor = DbtExecutor(
+            dbt_project_dir=dbt_project_dir,
+            profiles_dir=resources_folder,
+            extra_vars=extra_vars,
+            target_path=self.settings.target_path,
+            log_path=self.settings.log_path,
+        )
         validator = DbtValidator(
             connector=connector,
             executor=executor,

--- a/tests/test_parallelization.py
+++ b/tests/test_parallelization.py
@@ -1,0 +1,143 @@
+"""Unit tests for the per-test isolation and manifest-cache behaviour
+that enables parallel test execution under pytest-xdist."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pytest_dbt_duckdb import dbt_executor as dbt_executor_module
+from pytest_dbt_duckdb.dbt_executor import DbtExecutor
+from pytest_dbt_duckdb.plugin import PyDuckSettings
+
+
+@pytest.fixture(autouse=True)
+def _clear_parse_cache() -> None:
+    """Each test gets a clean cache so memoisation assertions are deterministic."""
+    dbt_executor_module._PARSE_CACHE.clear()
+
+
+class TestPyDuckSettings:
+    def test_target_path_is_under_temp_dir(self, tmp_path) -> None:
+        settings = PyDuckSettings(temp_dir=str(tmp_path))
+        assert settings.target_path == os.path.join(str(tmp_path), "dbt_target")
+
+    def test_log_path_is_under_temp_dir(self, tmp_path) -> None:
+        settings = PyDuckSettings(temp_dir=str(tmp_path))
+        assert settings.log_path == os.path.join(str(tmp_path), "dbt_logs")
+
+    def test_target_and_log_paths_are_unique_per_settings_instance(self, tmp_path) -> None:
+        a = PyDuckSettings(temp_dir=str(tmp_path / "a"))
+        b = PyDuckSettings(temp_dir=str(tmp_path / "b"))
+        assert a.target_path != b.target_path
+        assert a.log_path != b.log_path
+
+
+class TestDbtExecutorCommandConstruction:
+    def _capture_invoke(self, executor: DbtExecutor, command: str = "build") -> list[str]:
+        """Run executor.execute and capture the argv passed to dbtRunner.invoke."""
+        with patch.object(dbt_executor_module, "dbtRunner") as runner_cls:
+            runner = MagicMock()
+            runner_cls.return_value = runner
+            executor.execute(command=command)
+            args, _ = runner.invoke.call_args
+        return list(args[0])
+
+    def test_omits_target_and_log_path_flags_when_unset(self) -> None:
+        executor = DbtExecutor(dbt_project_dir="/proj", profiles_dir="/profiles")
+        argv = self._capture_invoke(executor)
+        assert "--target-path" not in argv
+        assert "--log-path" not in argv
+
+    def test_appends_target_path_after_subcommand(self) -> None:
+        executor = DbtExecutor(
+            dbt_project_dir="/proj",
+            profiles_dir="/profiles",
+            target_path="/tmp/test_target",
+        )
+        argv = self._capture_invoke(executor, command="build")
+        assert "--target-path" in argv
+        assert argv[argv.index("--target-path") + 1] == "/tmp/test_target"
+        # subcommand must precede --target-path (per dbt CLI convention)
+        assert argv.index("build") < argv.index("--target-path")
+
+    def test_prepends_log_path_before_subcommand(self) -> None:
+        executor = DbtExecutor(
+            dbt_project_dir="/proj",
+            profiles_dir="/profiles",
+            log_path="/tmp/test_logs",
+        )
+        argv = self._capture_invoke(executor, command="parse")
+        assert "--log-path" in argv
+        assert argv[argv.index("--log-path") + 1] == "/tmp/test_logs"
+        # --log-path is a global flag and must precede the subcommand
+        assert argv.index("--log-path") < argv.index("parse")
+
+    def test_target_path_does_not_collide_across_executors(self) -> None:
+        a = DbtExecutor(dbt_project_dir="/p", profiles_dir="/pf", target_path="/tmp/a")
+        b = DbtExecutor(dbt_project_dir="/p", profiles_dir="/pf", target_path="/tmp/b")
+        argv_a = self._capture_invoke(a)
+        argv_b = self._capture_invoke(b)
+        assert argv_a[argv_a.index("--target-path") + 1] == "/tmp/a"
+        assert argv_b[argv_b.index("--target-path") + 1] == "/tmp/b"
+
+
+class TestParseProjectMemoisation:
+    def _make_executor(self, **overrides: Any) -> DbtExecutor:
+        kwargs: dict[str, Any] = {"dbt_project_dir": "/proj", "profiles_dir": "/profiles"}
+        kwargs.update(overrides)
+        return DbtExecutor(**kwargs)
+
+    def _patched_parse(self, executor: DbtExecutor):
+        """Run parse_project with a stubbed dbt parse result, returning the call count."""
+        sentinel_node = MagicMock()
+        sentinel_node.schema = "s"
+        sentinel_node.identifier = "t"
+        sentinel_node.columns = {"id": MagicMock()}
+
+        fake_result = MagicMock()
+        fake_result.result.sources.values.return_value = []
+        fake_result.result.nodes.values.return_value = [sentinel_node]
+
+        execute = MagicMock(return_value=fake_result)
+        with patch.object(executor, "execute", execute):
+            manifest = executor.parse_project()
+        return manifest, execute.call_count
+
+    def test_first_call_invokes_dbt_parse(self) -> None:
+        executor = self._make_executor()
+        manifest, calls = self._patched_parse(executor)
+        assert "s.t" in manifest
+        assert calls == 1
+
+    def test_second_call_with_same_key_skips_dbt_parse(self) -> None:
+        executor = self._make_executor()
+        self._patched_parse(executor)  # warm cache
+        _, calls = self._patched_parse(executor)
+        assert calls == 0
+
+    def test_different_extra_vars_yield_different_cache_entries(self) -> None:
+        a = self._make_executor(extra_vars={"x": 1})
+        b = self._make_executor(extra_vars={"x": 2})
+        _, calls_a = self._patched_parse(a)
+        _, calls_b = self._patched_parse(b)
+        assert calls_a == 1
+        assert calls_b == 1  # different vars => cache miss => second parse
+
+    def test_extra_vars_key_is_order_independent(self) -> None:
+        a = self._make_executor(extra_vars={"x": 1, "y": 2})
+        b = self._make_executor(extra_vars={"y": 2, "x": 1})
+        self._patched_parse(a)
+        _, calls_b = self._patched_parse(b)
+        assert calls_b == 0  # same key after sort => cache hit
+
+    def test_target_path_does_not_affect_cache_key(self) -> None:
+        a = self._make_executor(target_path="/tmp/a")
+        b = self._make_executor(target_path="/tmp/b")
+        self._patched_parse(a)
+        _, calls_b = self._patched_parse(b)
+        # Manifest is invariant w.r.t. target_path; target_path only affects on-disk artifacts.
+        assert calls_b == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1351,7 +1351,7 @@ wheels = [
 
 [[package]]
 name = "pytest-dbt-duckdb"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "." }
 dependencies = [
     { name = "absl-py" },
@@ -1366,11 +1366,15 @@ dependencies = [
     { name = "ruamel-yaml" },
 ]
 
+[package.optional-dependencies]
+parallel = [
+    { name = "pytest-xdist" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pre-commit" },
-    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "tox" },
 ]
@@ -1393,14 +1397,15 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.7.1" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-env", specifier = ">=1.1.5" },
+    { name = "pytest-xdist", marker = "extra == 'parallel'", specifier = ">=3.6.0" },
     { name = "ruamel-yaml", specifier = ">=0.18.10" },
 ]
+provides-extras = ["parallel"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.14.1" },
     { name = "pre-commit", specifier = ">=4.1.0" },
-    { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "ruff", specifier = ">=0.9.3" },
     { name = "tox", specifier = ">=4.24.1" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -412,6 +412,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1361,6 +1370,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "tox" },
 ]
@@ -1390,6 +1400,7 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.14.1" },
     { name = "pre-commit", specifier = ">=4.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "ruff", specifier = ">=0.9.3" },
     { name = "tox", specifier = ">=4.24.1" },
 ]
@@ -1411,6 +1422,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/13/12/9c87d0ca45d5992473208bcef2828169fa7d39b8d7fc6e3401f5c08b8bf7/pytest_env-1.2.0.tar.gz", hash = "sha256:475e2ebe8626cee01f491f304a74b12137742397d6c784ea4bc258f069232b80", size = 8973, upload-time = "2025-10-09T19:15:47.42Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/98/822b924a4a3eb58aacba84444c7439fce32680592f394de26af9c76e2569/pytest_env-1.2.0-py3-none-any.whl", hash = "sha256:d7e5b7198f9b83c795377c09feefa45d56083834e60d04767efd64819fc9da00", size = 6251, upload-time = "2025-10-09T19:15:46.077Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Isolate dbt's on-disk artifacts per test by routing `--log-path` / `--target-path` into the existing per-test temp dir, so concurrent xdist workers no longer race on `target/`, `logs/`, or the partial-parse cache under `tests/dummy_gummy/`.
- Memoise `DbtExecutor.parse_project` per `(project_dir, profiles_dir, extra_vars)` so repeated scenarios within a worker skip `dbt parse` after the first call.
- Add `pytest-xdist` to the dev group, switch CI to `pytest -v -n auto`, and document the parallel workflow in `docs/usage.md`.

Also adds a `CLAUDE.md` repo guide (separate commit) capturing the architecture bits that aren't obvious from reading code.

## Results
| | Before | After |
|---|---|---|
| Serial wall (2 scenarios) | 17.74s | 11.54s (with 12 extra unit tests) |
| `-n auto` ×5 consecutive | n/a | 5/5 green, ~10.5s wall each |
| Project-dir artifact leakage | yes (`target/`, `logs/`) | none |

## Test plan
- [x] Capture baseline serial timing on `main` (17.74s wall)
- [x] Serial run after changes — 14 tests pass in 11.54s
- [x] `pytest -n auto` ×5 consecutive runs — 5/5 green, no flakes
- [x] `mypy` — clean
- [x] `ruff check` + `ruff format --check` — clean
- [x] Confirm `tests/dummy_gummy/target/` and `logs/` stay absent during runs
- [x] New `tests/test_parallelization.py` (12 tests) covers path properties, CLI flag positioning (`--log-path` before / `--target-path` after the subcommand), and cache hit/miss/key-equivalence
- [x] `DuckFixture.execute_dbt` public signature unchanged — no break for downstream consumers

- [x] **Yes, AI assisted with this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)